### PR TITLE
chore: updates after repo moved orgs

### DIFF
--- a/.github/workflows/capmvm-kubernetes-manual.yml
+++ b/.github/workflows/capmvm-kubernetes-manual.yml
@@ -11,6 +11,9 @@ defaults:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: Login to container registry

--- a/.github/workflows/capmvm-kubernetes.yml
+++ b/.github/workflows/capmvm-kubernetes.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: Build image
@@ -25,6 +27,9 @@ jobs:
   release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: Login to container registry

--- a/.github/workflows/flintlock-ubuntu-base.yml
+++ b/.github/workflows/flintlock-ubuntu-base.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: Build image
@@ -25,6 +27,9 @@ jobs:
   release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: Login to container registry

--- a/.github/workflows/kernel-images.yml
+++ b/.github/workflows/kernel-images.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +31,9 @@ jobs:
   release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+          contents: read
+          packages: write
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# image-builder
-Image building for Weaveworks projects.
+# Image Builder
+
+Image building for **Weaveworks Liquid Metal** projects.

--- a/capmvm/kubernetes/Dockerfile
+++ b/capmvm/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/weaveworks/flintlock-ubuntu-base:20.04
+FROM ghcr.io/weaveworks-liquidmetal/flintlock-ubuntu-base:20.04
 
 
 ARG ARCH="amd64"

--- a/capmvm/kubernetes/Makefile
+++ b/capmvm/kubernetes/Makefile
@@ -2,7 +2,7 @@ DOCKER := docker
 BUILD_DATE:=$(shell date --rfc-3339=seconds)
 GIT_SHA:=$(shell git rev-parse HEAD)
 
-REGISTRY?=ghcr.io/weaveworks
+REGISTRY?=ghcr.io/weaveworks-liquidmetal
 IMAGE_NAME?=$(REGISTRY)/capmvm-kubernetes
 CONTAINERD_VERSION?=1.5.9
 TAG?=$(shell git rev-parse --short HEAD)
@@ -16,8 +16,8 @@ build-%:
 		--build-arg CONTAINERD_VERSION=$(CONTAINERD_VERSION) \
 		--label "org.opencontainers.image.created"="$(BUILD_DATE)" \
 		--label "org.opencontainers.image.authors"="Liquid Metal Authors" \
-		--label "org.opencontainers.image.url"="https://github.com/weaveworks/image-builder" \
-		--label "org.opencontainers.image.source"="https://github.com/weaveworks/image-builder/tree/main/capmvm/kubernetes" \
+		--label "org.opencontainers.image.url"="https://github.com/weaveworks-liquidmetal/image-builder" \
+		--label "org.opencontainers.image.source"="https://github.com/weaveworks-liquidmetal/image-builder/tree/main/capmvm/kubernetes" \
 		--label "org.opencontainers.image.revision"="$(GIT_SHA)" \
 		--label "org.opencontainers.image.vendor"="Weaveworks" \
 		--label "org.opencontainers.image.licenses"="MPL-2.0" \

--- a/flintlock/base-ubuntu/Makefile
+++ b/flintlock/base-ubuntu/Makefile
@@ -1,6 +1,6 @@
 DOCKER := docker
 
-REGISTRY?=ghcr.io/weaveworks
+REGISTRY?=ghcr.io/weaveworks-liquidmetal
 IMAGE_NAME?=$(REGISTRY)/flintlock-ubuntu-base
 RELEASE?=20.04
 IS_LATEST?=

--- a/flintlock/kernel/Makefile
+++ b/flintlock/kernel/Makefile
@@ -1,6 +1,6 @@
 DOCKER := docker
 
-REGISTRY?=ghcr.io/weaveworks
+REGISTRY?=ghcr.io/weaveworks-liquidmetal
 IMAGE_NAME?=$(REGISTRY)/flintlock-kernel
 BUILDER_IMAGE_NAME?=flintlock-kernel-builder
 KERNEL_VERSIONS ?= 4.19.215 5.10.77 # If you update this list, please remember to update the matrix in the kernel-images.yml github action!


### PR DESCRIPTION
A small number of changes as a result of the repo moving from the
`weaveworks` over to the `weavework-liquidmetal` org.

Most of the changes relate to container image registry names.

Signed-off-by: Richard Case <richard@weave.works>