### PR TITLE
chore: kernel image changes after repo move

### DIFF
--- a/.github/workflows/kernel-images.yml
+++ b/.github/workflows/kernel-images.yml
@@ -1,4 +1,4 @@
-name: Build and release kernel images
+name: Kernel - Build and release
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/

--- a/flintlock/kernel/Makefile
+++ b/flintlock/kernel/Makefile
@@ -1,6 +1,6 @@
 DOCKER := docker
 
-REGISTRY?=ghcr.io/weaveworks
+REGISTRY?=ghcr.io/weaveworks-liquidmetal
 IMAGE_NAME?=$(REGISTRY)/flintlock-kernel
 BUILDER_IMAGE_NAME?=flintlock-kernel-builder
 KERNEL_VERSIONS ?= 4.19.215 5.10.77 # If you update this list, please remember to update the matrix in the kernel-images.yml github action!


### PR DESCRIPTION
A small number of changes as a result of the repo moving from the
weaveworks over to the weavework-liquidmetal org.

Signed-off-by: Richard Case <richard@weave.works>