### PR TITLE
fix: cloud hypervisor kernel GHA permission

### DIFF
--- a/.github/workflows/cloudhypervisor-kernel-images.yml
+++ b/.github/workflows/cloudhypervisor-kernel-images.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +31,9 @@ jobs:
   release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
There are missing permissions for the Cloud Hypervisor GHA which means it can't publish the image to the regsirty.

Signed-off-by: Richard Case <richard.case@outlook.com>